### PR TITLE
fix ionic chat links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@
 - [Telegram chat for Angular-universal-ru (общаемся на темы серверного рендеринга и Angular Universal)](https://t.me/angular_universal_ru)
 - [Telegram chat for ngMoscow (вся Angular движуха Москвы и не только)](https://t.me/ngMoscow)
 - [Telegram chat for Nest RU (общаемся на темы Nest и Angular)](https://t.me/nest_ru)
-- [Telegram chat for Ionic RU (общаемся на темы Ionic и Angular)](https://t.me/pro_ionic)
+- [Telegram chat for Ionic RU (общаемся на темы Ionic и Angular)](https://t.me/ionic_ru)
 - [Telegram chat for NativeScript RU (общаемся на темы NativeScript и Angular)](https://t.me/nativescript_ru)

--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
 	          </div>
 
 	          <div class="card-text-container">
-	          	<a href="https://t.me/pro_ionic" target="_blank">
+	          	<a href="https://t.me/ionic_ru" target="_blank">
 	            	<span class="card-text-title chat-angular-ionic">Ionic RU</span>
 	            </a>
 	            <p class="card-text-subtitle">Общаемся на темы Ionic и Angular</p>


### PR DESCRIPTION
change ionic chat links from t.me/pro_ionic to t.me/ionic_ru